### PR TITLE
Pocket provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,43 @@ It should take no more than 5 minutes to get started with Portis 🚀
 
    const portis = new Portis('YOUR_DAPP_ID', 'mainnet');
    const web3 = new Web3(portis.provider);
+
+   // If you want to tap into the Pocket Network use this alternative provider instead
+   const web3 = new Web3(portis.pocketProvider);
+   ```
+
+1. Verify everything works by calling a web3 method such as getAccounts:
+
+   ```javascript
+   web3.eth.getAccounts((error, accounts) => {
+     console.log(accounts);
+   });
+   ```
+
+1. You are good to go! 👍
+
+For more information see our [docs](https://docs.portis.io) 📕
+
+## Quick Start using Pocket Network
+
+Pocket and Portis have partnered up to bring the power of decentralized infrastructure to your Portis apps.
+
+1. Register a DApp in the [Portis Dashboard](https://dashboard.portis.io), and copy your DApp ID.
+
+1. Install Portis and Web3
+
+   ```shell
+   npm install @portis/web3 web3
+   ```
+
+1. Import and initialize a web3 instance
+
+   ```javascript
+   import Portis from '@portis/web3';
+   import Web3 from 'web3';
+
+   const portis = new Portis('YOUR_DAPP_ID', 'mainnet');
+   const web3 = new Web3(portis.provider);
    ```
 
 1. Verify everything works by calling a web3 method such as getAccounts:

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ Pocket and Portis have partnered up to bring the power of decentralized infrastr
    import Portis from '@portis/web3';
    import Web3 from 'web3';
 
-   const portis = new Portis('YOUR_DAPP_ID', 'mainnet');
-   const web3 = new Web3(portis.provider);
+   const portis = new Portis('YOUR_DAPP_ID', 'mainnet', {
+     pocketDevID: 'YOUR_POCKET_DEV_ID_HERE'
+   });
+   const web3 = new Web3(portis.pocketProvider);
    ```
 
 1. Verify everything works by calling a web3 method such as getAccounts:

--- a/packages/portis-web3/package-lock.json
+++ b/packages/portis-web3/package-lock.json
@@ -675,7 +675,7 @@
         "eth-block-tracker": "^4.2.0",
         "eth-json-rpc-filters": "^4.0.2",
         "eth-json-rpc-infura": "^3.1.0",
-        "eth-json-rpc-middleware": "github:radotzki/eth-json-rpc-middleware#8acc43df4a8c0c7f6d212af9163d379211dad4c7",
+        "eth-json-rpc-middleware": "github:radotzki/eth-json-rpc-middleware#patch-1",
         "eth-sig-util": "^1.4.2",
         "ethereumjs-block": "^1.2.2",
         "ethereumjs-tx": "^1.2.0",
@@ -1128,6 +1128,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -3015,6 +3024,29 @@
         "json-rpc-engine": "^5.0.0",
         "lodash.flatmap": "^4.5.0",
         "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "eth-json-rpc-middleware": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.1.3.tgz",
+          "integrity": "sha512-g663u/zK11huhkmP7jeFihUcwA2acYglIw2wO50G7zIXYoZ6L+NHJjEwW7gwVMEUy7rgB3Qx76ql/+UYJfIb9w==",
+          "requires": {
+            "btoa": "^1.2.1",
+            "clone": "^2.1.1",
+            "eth-query": "^2.1.2",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.6.0",
+            "ethereumjs-tx": "^1.3.3",
+            "ethereumjs-util": "^5.1.2",
+            "ethereumjs-vm": "^2.6.0",
+            "fetch-ponyfill": "^4.0.0",
+            "json-rpc-engine": "^5.0.0",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "pify": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        }
       }
     },
     "eth-json-rpc-infura": {
@@ -3178,7 +3210,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       }
     },
@@ -3632,6 +3664,24 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "follow-redirects": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "requires": {
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3717,7 +3767,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3738,12 +3789,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3758,17 +3811,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3885,7 +3941,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3897,6 +3954,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3911,6 +3969,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3918,12 +3977,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3942,6 +4003,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4022,7 +4084,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4034,6 +4097,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4119,7 +4183,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4155,6 +4220,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4174,6 +4240,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4217,12 +4284,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4623,8 +4692,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -5742,6 +5810,14 @@
         "find-up": "^2.1.0"
       }
     },
+    "pocket-js-core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/pocket-js-core/-/pocket-js-core-0.0.3.tgz",
+      "integrity": "sha512-OUTEvEVutdjLT6YyldvAlSebpBueUUWg2XKxGNt5u3QqrmLpBOOBmdDnGMNJ+lEwXtko+JqgwFq+HTi4g1QDVg==",
+      "requires": {
+        "axios": "^0.18.0"
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -6268,18 +6344,11 @@
       }
     },
     "sha3": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
-      "integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
+      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
       "requires": {
-        "nan": "2.10.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        }
+        "nan": "2.13.2"
       }
     },
     "shebang-command": {

--- a/packages/portis-web3/package.json
+++ b/packages/portis-web3/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@portis/web3-provider-engine": "1.0.10",
     "ethereumjs-util": "5.2.0",
-    "penpal": "3.0.7"
+    "penpal": "3.0.7",
+    "pocket-js-core": "0.0.3"
   }
 }

--- a/packages/portis-web3/src/index.ts
+++ b/packages/portis-web3/src/index.ts
@@ -12,6 +12,7 @@ import { getTxGas } from './utils/getTxGas';
 import { Query } from './utils/query';
 import { styles } from './styles';
 import { validateSecureOrigin } from './utils/secureOrigin';
+import PocketJSCore from 'pocket-js-core';
 
 const version = '$$PORTIS_SDK_VERSION$$';
 const widgetUrl = 'https://widget.portis.io';
@@ -25,6 +26,7 @@ export default class Portis {
     widgetFrame: HTMLDivElement;
   }>;
   provider;
+  pocketProvider;
   private noncesCache = {};
   private _selectedAddress: string;
   private _network: string;
@@ -43,7 +45,18 @@ export default class Portis {
       registerPageByDefault: options.registerPageByDefault,
     };
     this.widget = this._initWidget();
-    this.provider = this._initProvider();
+
+    // Setup pocket
+    if (options.pocketDevID) {
+      let pocket = new PocketJSCore.Pocket({
+        devID: options.pocketDevID,
+        networkName: 'ETH',
+        netIDs: [this.config.network.chainId]
+      });
+      this.pocketProvider = this._initProvider(pocket);
+    } else {
+      this.provider = this._initProvider();
+    }
   }
 
   changeNetwork(network: string | INetwork, gasRelay?: boolean) {
@@ -158,7 +171,7 @@ export default class Portis {
     });
   }
 
-  private _initProvider() {
+  private _initProvider(pocket?: PocketJSCore.Pocket) {
     const engine = new ProviderEngine();
     const query = new Query(engine);
 
@@ -212,7 +225,7 @@ export default class Portis {
         default:
           var message = `The Portis Web3 object does not support synchronous methods like ${
             payload.method
-          } without a callback parameter.`;
+            } without a callback parameter.`;
           throw new Error(message);
       }
 
@@ -287,18 +300,47 @@ export default class Portis {
       }),
     );
 
-    engine.addProvider({
-      setEngine: _ => _,
-      handleRequest: async (payload, next, end) => {
-        const widgetCommunication = (await this.widget).communication;
-        const { error, result } = await widgetCommunication.relay(payload, this.config);
-        if (payload.method === 'net_version') {
-          this._network = result;
-          engine.networkVersion = this._network;
-        }
-        end(error, result);
-      },
-    });
+    // Check the pocket provider flag and add the pocket provider
+    if (pocket) {
+      engine.addProvider({
+        setEngine: _ => _,
+        handleRequest: async (payload, next, end) => {
+          var response = await pocket.sendRelay(new PocketJSCore.Relay('ETH', this.config.network.chainId, JSON.stringify(payload), pocket.configuration));
+          var result;
+          var error;
+          if (result instanceof Error || !result) {
+            error = result || new Error('Unknown error');
+            result = null;
+          } else {
+            try {
+              result = JSON.parse(response).result;
+              error = null;
+            } catch(e) {
+              result = null;
+              error = e;
+            }
+          }
+          if (payload.method === 'net_version') {
+            this._network = result;
+            engine.networkVersion = this._network;
+          }
+          end(error, result);
+        },
+      });
+    } else {
+      engine.addProvider({
+        setEngine: _ => _,
+        handleRequest: async (payload, next, end) => {
+          const widgetCommunication = (await this.widget).communication;
+          const { error, result } = await widgetCommunication.relay(payload, this.config);
+          if (payload.method === 'net_version') {
+            this._network = result;
+            engine.networkVersion = this._network;
+          }
+          end(error, result);
+        },
+      });
+    }
 
     engine.enable = () =>
       new Promise((resolve, reject) => {

--- a/packages/portis-web3/src/interfaces.ts
+++ b/packages/portis-web3/src/interfaces.ts
@@ -29,6 +29,7 @@ export interface IOptions {
   scope?: Scope[];
   gasRelay?: boolean;
   registerPageByDefault?: boolean;
+  pocketDevID?: string;
 }
 
 export interface ITransactionRequest {


### PR DESCRIPTION
This PR includes the `pocket-js-core` package, which allows Portis to send requests to any Ethereum network via Pocket Core MVP.

The only requisite for a developer is to request a Pocket Core Developer ID and pass it in the Portis configuration as one of the Options parameters.