### PR TITLE
In3 Client integration

### DIFF
--- a/packages/portis-web3/src/index.ts
+++ b/packages/portis-web3/src/index.ts
@@ -1,5 +1,6 @@
 import ProviderEngine from '@portis/web3-provider-engine';
 import CacheSubprovider from '@portis/web3-provider-engine/subproviders/cache.js';
+import In3Subprovider from '@portis/web3-provider-engine/subproviders/in3.js';
 import FixtureSubprovider from '@portis/web3-provider-engine/subproviders/fixture.js';
 import FilterSubprovider from '@portis/web3-provider-engine/subproviders/filters.js';
 import HookedWalletSubprovider from '@portis/web3-provider-engine/subproviders/hooked-wallet.js';
@@ -52,7 +53,7 @@ export default class Portis {
     this._valiadateParams(dappId, network, options);
     this.config = {
       dappId,
-      network: networkAdapter(network, options.gasRelay),
+      network: networkAdapter(network, options.gasRelay, options.useIn3),
       version: VERSION,
       scope: options.scope,
       registerPageByDefault: options.registerPageByDefault,
@@ -61,10 +62,25 @@ export default class Portis {
     this.provider = this._initProvider(options);
   }
 
-  changeNetwork(network: string | INetwork, gasRelay?: boolean) {
-    const newNetwork = networkAdapter(network, gasRelay);
+  changeNetwork(network: string | INetwork, gasRelay?: boolean, useIn3?: boolean) {
+    const newNetwork = networkAdapter(network, gasRelay, useIn3);
     this.clearSubprovider(NonceSubprovider);
     this.clearSubprovider(CacheSubprovider);
+
+    const subprovider = this.provider._providers.find(subprovider => subprovider instanceof In3Subprovider);
+
+    //if a in3 provider was added then remove it.
+    if (subprovider) this.provider.removeProvider(subprovider);
+
+    //if user plans to useIn3 with the change then add the in3 Provider.
+    if (useIn3) {
+      const in3Config = Object.assign({}, newNetwork);
+      delete in3Config.nodeUrl;
+
+      //add the in3 subprovider to the engine
+      this.provider.addProvider(new In3Subprovider(in3Config));
+    }
+
     this.config.network = newNetwork;
   }
 
@@ -348,7 +364,13 @@ export default class Portis {
       }),
     );
 
-    if (!options.pocketDevId) {
+    if (options.useIn3) {
+      const in3Config = Object.assign({}, this.config.network);
+      delete in3Config.nodeUrl;
+
+      //add the in3 subprovider to the engine
+      engine.addProvider(new In3Subprovider(in3Config));
+    } else if (!options.pocketDevId && !options.useIn3) {
       engine.addProvider({
         setEngine: _ => _,
         handleRequest: async (payload, next, end) => {

--- a/packages/portis-web3/src/interfaces.ts
+++ b/packages/portis-web3/src/interfaces.ts
@@ -50,6 +50,7 @@ export interface IOptions {
   gasRelay?: boolean;
   registerPageByDefault?: boolean;
   pocketDevId?: string;
+  useIn3?: boolean;
 }
 
 export interface ITransactionRequest {

--- a/packages/portis-web3/src/networks.ts
+++ b/packages/portis-web3/src/networks.ts
@@ -1,12 +1,28 @@
 import { INetwork } from './interfaces';
 
-export function networkAdapter(network: string | INetwork, gasRelay?: boolean) {
+const IN3_SUPPORTED_CHAINS = ['mainnet', 'kovan', 'goerli'];
+
+export function networkAdapter(network: string | INetwork, gasRelay?: boolean, useIn3?: boolean) {
   const networkObj = typeof network === 'string' ? Object.assign({}, networks[network]) : network;
 
   if (typeof networkObj !== 'object') {
     throw new Error(
       "[Portis] illegal 'network' parameter. Read more about it here: https://docs.portis.io/#/configuration?id=network",
     );
+  }
+
+  if (useIn3) {
+    if (!(networkObj.chainId && networkObj['requestCount'] && networkObj['minDeposit'])) {
+      throw new Error(
+        '[Portis-In3] a in3 config with chainId, requestCount and minDeposit is required. Some or all are missing',
+      );
+    } else if (!IN3_SUPPORTED_CHAINS.includes(networkObj.chainId)) {
+      throw new Error(
+        '[Portis-In3] Only mainnet, kovan and goerli are supported with In3. Specify chainId as ["kovan", "mainnet", "goerli"]',
+      );
+    } else {
+      networkObj.nodeUrl = networks[networkObj.chainId].nodeUrl;
+    }
   }
 
   if (!networkObj.nodeUrl) {

--- a/packages/portis-web3/webpack.config.babel.js
+++ b/packages/portis-web3/webpack.config.babel.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 export default () => [
   {
@@ -15,13 +16,14 @@ export default () => [
       library: 'Portis',
       libraryExport: 'default',
     },
+    plugins: [new webpack.SourceMapDevToolPlugin({})],
     module: {
       rules: [
         {
           test: /\.(js)$/,
           include: [
             path.resolve(__dirname, 'src'),
-            path.resolve(__dirname, 'node_modules/@portis/web3-provider-engine')
+            path.resolve(__dirname, 'node_modules/@portis/web3-provider-engine'),
           ],
           use: 'babel-loader',
         },


### PR DESCRIPTION
**Pretext:**

Slock.it just released the first stable version of its blockchain client, INCUBED (IN3). INCUBED unlike Infura connects to the Ethereum Blockchain via an INcentivized Node Network which incentivises and distributes the trust on remote nodes while still keeping the bandwidth and storage requirements low. Such a client fits the requirements of wallets like portis.

**New Functionality:**

_Normal usage(Current)_

```
import Portis from '@portis/web3';
import Web3 from 'web3';

const portis = new Portis('YOUR_DAPP_ID', 'mainnet');
const web3 = new Web3(portis.provider);
```

_Using IN3_

```
const in3Config = {
  chainId: 'kovan',
  requestCount: 5,
  minDeposit: 0.01
}

const portis = new Portis('dapp-id', in3Config, {useIn3: true});
const web3 = new Web3(portis.provider);
```

**Code Changes:**

1. Addition of extra flag to options parameter of the constructor. This flag is used to switch on/off in3.

```
interface IOptions {
  scope?: Scope[];
  gasRelay?: boolean;
  registerPageByDefault?: boolean;
  pocketDevId?: string;
  useIn3?: boolean;
}
```

2. Function signature change for `networkAdapter` to include extra boolean parameter to handle in3 networks.

New Signature: `networkAdapter(network: string | INetwork, gasRelay?: boolean, useIn3?: boolean)`

3. Function signature change for `changeNetwork` to include extra boolean parameter to handle in3 networks.

New Signature: `changeNetwork(network: string | INetwork, gasRelay?: boolean, useIn3?: boolean)`

4. Functionality Change: In3 is provided as an alternative to pocket and infura(iframe). So developer cannot turn on in3 and pocket/infura at the same time.

> NOTE: None of the changes are breaking.

**Dependency Changes:**

1. Added `In3Subprovider` to the portis web3 provider engine library. See pull request

**Config Changes:**

1. Added source map plugin to webpack config for better debugging.

**Possible Improvements:** (with the help of Portis Team).

1. The property of `nodeUrl` is internally used in the iframe for infura communication. If we can remove this dependency of infura in the iframe and somehow relay the requests from inside of iframe to the in3 client it would make the flow much more smoother and code much more cleaner.
2. The SDK requires tests.

**Links:**

- [Read the Docs](https://in3.readthedocs.io/en/latest/)
- [Release Blog](https://blog.slock.it/incubed-stable-release-c35b3a4ec10a)
- [How IN3 Works](http://how-in3-works.slock.it/)
