### PR TITLE
Replaced retrieveSession with setSdkConfig, to let the widget to lazily retrieve the session.

### DIFF
--- a/packages/portis-web3/src/index.ts
+++ b/packages/portis-web3/src/index.ts
@@ -229,7 +229,7 @@ export default class Portis {
     connection.iframe.style.border = '0 transparent';
 
     const communication = await connection.promise;
-    communication.retrieveSession(this.config);
+    communication.setSdkConfig(this.config);
 
     return { communication, iframe: connection.iframe, widgetFrame };
   }

--- a/packages/portis-web3/src/interfaces.ts
+++ b/packages/portis-web3/src/interfaces.ts
@@ -32,6 +32,7 @@ export interface IConnectionMethods {
   }>;
   showBitcoinWallet: (path: string, config: ISDKConfig) => Promise<void>;
   retrieveSession: (config: ISDKConfig) => Promise<void>;
+  setSdkConfig: (config: ISDKConfig) => Promise<void>;
 }
 
 export interface ISDKConfig {


### PR DESCRIPTION
Do not merge until code splitting feature is merged in Widget.