### PR TITLE
128 batching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Thumbs.db
 .db
 node_modules
 lerna-debug.log
+.idea

--- a/packages/portis-web3/package-lock.json
+++ b/packages/portis-web3/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@portis/web3",
-  "version": "3.0.0",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -290,6 +290,12 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
+      "dev": true
+    },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
     "abbrev": {
@@ -2886,6 +2892,29 @@
         "locate-path": "^2.0.0"
       }
     },
+    "find-yarn-workspace-root": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz",
+      "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^4.0.3",
+        "micromatch": "^3.1.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -2952,6 +2981,17 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -3722,6 +3762,15 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -3752,6 +3801,15 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
+    },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
     },
     "latest-version": {
       "version": "3.1.0",
@@ -4624,6 +4682,100 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "patch-package": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz",
+      "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^1.2.1",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
@@ -4691,7 +4843,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pify": {
       "version": "3.0.0",
@@ -5852,6 +6005,15 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -6014,6 +6176,12 @@
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6427,7 +6595,7 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {

--- a/packages/portis-web3/package.json
+++ b/packages/portis-web3/package.json
@@ -16,7 +16,8 @@
     "insert-version": "node utils/replace.js",
     "print-integrity": "node utils/integrity.js",
     "prepublishOnly": "PORTIS_WIDGET_URL=\"\" npm run build",
-    "start": "nodemon --watch src --watch utils -e ts -x \"npm run build\""
+    "start": "nodemon --watch src --watch utils -e ts -x \"npm run build\"",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "babel-core": "6.26.0",
@@ -31,7 +32,8 @@
     "rimraf": "2.6.1",
     "typescript": "3.2.2",
     "webpack": "4.28.3",
-    "webpack-cli": "3.1.2"
+    "webpack-cli": "3.1.2",
+    "patch-package": "6.2.2"
   },
   "keywords": [
     "blockchain",
@@ -41,9 +43,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "web3-provider-engine": "16.0.0",
     "ethereumjs-util": "5.2.0",
     "penpal": "3.0.7",
-    "pocket-js-core": "0.0.3"
+    "pocket-js-core": "0.0.3",
+    "web3-provider-engine": "16.0.0"
   }
 }

--- a/packages/portis-web3/package.json
+++ b/packages/portis-web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@portis/web3",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Portis Web3 SDK",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/portis-web3/patches/web3-provider-engine+16.0.0.patch
+++ b/packages/portis-web3/patches/web3-provider-engine+16.0.0.patch
@@ -1,0 +1,43 @@
+diff --git a/node_modules/web3-provider-engine/index.js b/node_modules/web3-provider-engine/index.js
+index 3a1b7d5..a4081c5 100644
+--- a/node_modules/web3-provider-engine/index.js
++++ b/node_modules/web3-provider-engine/index.js
+@@ -120,7 +120,7 @@ Web3ProviderEngine.prototype.sendAsync = function(payload, cb){
+ 
+     if (Array.isArray(payload)) {
+       // handle batch
+-      map(payload, self._handleAsync.bind(self), cb)
++      map(payload, handleAsyncBatch.bind(self), cb)
+     } else {
+       // handle single
+       self._handleAsync(payload, cb)
+@@ -129,6 +129,11 @@ Web3ProviderEngine.prototype.sendAsync = function(payload, cb){
+   })
+ }
+ 
++function handleAsyncBatch(payload, finished) {
++  const self = this
++  const handleAsync = self._handleAsync.bind(self)
++  handleAsync(payload, finished, true)
++}
+ // private
+ 
+ Web3ProviderEngine.prototype._getBlockByNumberWithRetry = function(blockNumber, cb) {
+@@ -176,7 +181,7 @@ Web3ProviderEngine.prototype._getBlockByNumber = function(blockNumber, cb) {
+   })
+ }
+ 
+-Web3ProviderEngine.prototype._handleAsync = function(payload, finished) {
++Web3ProviderEngine.prototype._handleAsync = function(payload, finished, isBatch) {
+   var self = this
+   var currentProvider = -1
+   var result = null
+@@ -229,7 +234,7 @@ Web3ProviderEngine.prototype._handleAsync = function(payload, finished) {
+           code: -32000
+         }
+         // respond with both error formats
+-        finished(error, resultObj)
++        finished(isBatch ? null : error, resultObj)
+       } else {
+         finished(null, resultObj)
+       }


### PR DESCRIPTION
- Added `patch-package` library to apply patches to dependencies at install time
- created a patch for `web3-provider-engine` to prevent `handleAsync` from triggering an error in the async `map` function being used by `sendAsync`. This was originally halting execution of the batch any time a transaction was rejected. Details:

When a batch request is made, the payload sent to sendAsync in the web3 provider engine is an array of JSON RPC requests.
https://github.com/MetaMask/web3-provider-engine/blob/master/index.js#L121
The provider has to pass those requests one at a time to an asynchronous request handler which is ultimately what lets us display the prompt to the user asking them to allow or deny a transaction. The provider uses a third party library for this asynchronous mapping behavior
https://github.com/MetaMask/web3-provider-engine/blob/master/index.js#L123
https://caolan.github.io/async/v3/docs.html#map
In the docs, it says "If iteratee passes an error to its callback, the main callback (for the map function) is immediately called with the error.", which is what was happening. The iteratee in this case is the provider's  _handleAsync function which is passing an error to the callback any time that the RPC response contains an error
https://github.com/MetaMask/web3-provider-engine/blob/master/index.js#L231
This causes map to stop processing the batch immediately, so sendAsync 's cb gets invoked with an error and a single response (instead of the expected array of responses)