### PR TITLE
fix eth_signTypedData_v4 crash

### DIFF
--- a/patches/web3-provider-engine+16.0.1.patch
+++ b/patches/web3-provider-engine+16.0.1.patch
@@ -23,9 +23,9 @@ index 75576ec..2077f04 100644
            return self.validateTypedMessage(msgParams, cb);
          }, function (cb) {
 -          return self.processTypedMessage(msgParams, cb);
-+          return payload.method === 'eth_signTypedData_v3'
-+            ? self.processTypedMessageV3(msgParams, cb)
-+            : self.processTypedMessage(msgParams, cb);
++          return payload.method === 'eth_signTypedData'
++            ? self.processTypedMessage(msgParams, cb)
++            : self.processTypedMessageV3(msgParams, cb);
          }], end);
        }();
  


### PR DESCRIPTION
**Motivation:**

The EIP-712 moved to a new stage adding support for Array in typedData in the latest implementation `eth_signTypedData_v4`.
`eth_signTypedData_v4` is backward compatible with `eth_signTypedData_v3` so developers and wrapper libraries (such as `ethers`) tends to migrate RPC calls from the legacy `eth_signTypedData_v3`  to `eth_signTypedData_v4`.

Currently, Portis 
- Supports the v3 implementation via a custom handler `porcessTypedMessageV3` in `web3-provider-engine`
- Does NOT support the v4 implementation, `eth_signTypedData_v4` calls fallback to `porcessTypedMessage` and crash the widget (issue #126).

Taking advantage of the backward compatibility between `eth_signTypedData_v4` and `eth_signTypedData_v3` remapping `eth_signTypedData_v4` to `porcessTypedMessageV3` will prevent the widget to crash and allow most of the EIP-712 use cases (all typedData NOT containing array are compatible).

Finally, users using Arrays in typedData will receive the following error until Portis implements arrays support in the `porcessTypedMessageV3` handler
```
Error: Arrays currently unimplemented in encodeData
```

**Changes:**

This PR change the default handler for signTypedData methods from `processTypedMessage` to `processTypedMessageV3`.
Practically only the way `eth_signTypedData_v4` is handled will change from `processTypedMessage` to `processTypedMessageV3`.






